### PR TITLE
Support linked addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Options are the same as `resolve()` for all functions.
 
 #### `const generator = resolve.directory(dirname, parentURL[, options])`
 
+#### `const generator = resolve.linked(name, version[, options])`
+
 ## License
 
 Apache-2.0

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Options include:
   builtins: [],
   // The protocol to use for resolved builtin addon specifiers.
   builtinProtocol: 'builtin:',
+  // Whether or not addons linked ahead-of-time should be resolved.
+  linked: true,
+  // The protocol to use for addons linked ahead-of-time.
+  linkedProtocol: 'linked:',
   // The `<platform>-<arch>` combination to look for when resolving dynamic
   // addons. If `null`, only builtin specifiers can be resolved. In Bare,
   // pass `Bare.Addon.host`.

--- a/index.js
+++ b/index.js
@@ -230,7 +230,49 @@ exports.directory = function * (dirname, parentURL, opts = {}) {
     }
   }
 
+  if (yield * exports.linked(name, version, opts)) {
+    yielded = true
+  }
+
   return yielded
+}
+
+exports.linked = function * (name, version = null, opts = {}) {
+  const { linked = true, linkedProtocol = 'linked:', host = null } = opts
+
+  if (linked === false || host === null) return false
+
+  if (host.startsWith('darwin-') || host.startsWith('ios-')) {
+    if (version !== null) {
+      yield { resolution: new URL(linkedProtocol + 'lib' + name + '.' + version + '.dylib') }
+    }
+
+    yield { resolution: new URL(linkedProtocol + 'lib' + name + '.dylib') }
+
+    return true
+  }
+
+  if (host.startsWith('linux-') || host.startsWith('android-')) {
+    if (version !== null) {
+      yield { resolution: new URL(linkedProtocol + 'lib' + name + '.so.' + version) }
+    }
+
+    yield { resolution: new URL(linkedProtocol + 'lib' + name + '.so') }
+
+    return true
+  }
+
+  if (host.startsWith('win32-')) {
+    if (version !== null) {
+      yield { resolution: new URL(linkedProtocol + name + '-' + version + '.dll') }
+    }
+
+    yield { resolution: new URL(linkedProtocol + name + '.dll') }
+
+    return true
+  }
+
+  return false
 }
 
 exports.isWindowsDriveLetter = resolve.isWindowsDriveLetter

--- a/test.js
+++ b/test.js
@@ -381,3 +381,128 @@ test('resolutions map', (t) => {
 
   t.alike(result, ['file:///a/b/d.bare'])
 })
+
+test('linked module, darwin', (t) => {
+  function readPackage (url) {
+    if (url.href === 'file:///a/b/package.json') {
+      return {
+        name: 'e',
+        version: '1.2.3'
+      }
+    }
+
+    return null
+  }
+
+  const host = 'darwin-arm64'
+  const result = []
+
+  for (const resolution of resolve('e', new URL('file:///a/b/c'), { host }, readPackage)) {
+    result.push(resolution.href)
+  }
+
+  t.alike(result, [
+    'linked:libe.1.2.3.dylib',
+    'linked:libe.dylib'
+  ])
+})
+
+test('linked module, ios', (t) => {
+  function readPackage (url) {
+    if (url.href === 'file:///a/b/package.json') {
+      return {
+        name: 'e',
+        version: '1.2.3'
+      }
+    }
+
+    return null
+  }
+
+  const host = 'ios-arm64'
+  const result = []
+
+  for (const resolution of resolve('e', new URL('file:///a/b/c'), { host }, readPackage)) {
+    result.push(resolution.href)
+  }
+
+  t.alike(result, [
+    'linked:libe.1.2.3.dylib',
+    'linked:libe.dylib'
+  ])
+})
+
+test('linked module, linux', (t) => {
+  function readPackage (url) {
+    if (url.href === 'file:///a/b/package.json') {
+      return {
+        name: 'e',
+        version: '1.2.3'
+      }
+    }
+
+    return null
+  }
+
+  const host = 'linux-arm64'
+  const result = []
+
+  for (const resolution of resolve('e', new URL('file:///a/b/c'), { host }, readPackage)) {
+    result.push(resolution.href)
+  }
+
+  t.alike(result, [
+    'linked:libe.so.1.2.3',
+    'linked:libe.so'
+  ])
+})
+
+test('linked module, android', (t) => {
+  function readPackage (url) {
+    if (url.href === 'file:///a/b/package.json') {
+      return {
+        name: 'e',
+        version: '1.2.3'
+      }
+    }
+
+    return null
+  }
+
+  const host = 'android-arm64'
+  const result = []
+
+  for (const resolution of resolve('e', new URL('file:///a/b/c'), { host }, readPackage)) {
+    result.push(resolution.href)
+  }
+
+  t.alike(result, [
+    'linked:libe.so.1.2.3',
+    'linked:libe.so'
+  ])
+})
+
+test('linked module, win32', (t) => {
+  function readPackage (url) {
+    if (url.href === 'file:///a/b/package.json') {
+      return {
+        name: 'e',
+        version: '1.2.3'
+      }
+    }
+
+    return null
+  }
+
+  const host = 'win32-arm64'
+  const result = []
+
+  for (const resolution of resolve('e', new URL('file:///a/b/c'), { host }, readPackage)) {
+    result.push(resolution.href)
+  }
+
+  t.alike(result, [
+    'linked:e-1.2.3.dll',
+    'linked:e.dll'
+  ])
+})


### PR DESCRIPTION
This introduces support for "linked" addons, i.e. addons that have been dynamically linked with the program executable ahead of time. Such addons should be loaded via `uv_dlopen()` by passing the host dependant name of the shared object library rather than an absolute path to a `.bare` prebuild. The shared object libraries are named as follows on the supported hosts:

- `darwin`, `ios`: `lib<name>[.<version>].dylib`
- `linux`, `android`: `lib<name>.so[.<version>]`
- `win32`: `<name>[-<version>].dll`

Resolution of linked addons can be disabled by setting `opts.linked = false`.